### PR TITLE
Time in minutes and "open availability" only for open studio

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -29,6 +29,7 @@ hbs.registerHelper({
     'en-US',
     {
       hour: 'numeric',
+      minute: 'numeric',
       timeZone: 'America/Denver',
     },
   ).format(new Date(start)),

--- a/routes/index.js
+++ b/routes/index.js
@@ -19,11 +19,13 @@ hbs.registerHelper({
     const date = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(start));
     return `${day}, ${date}`;
   },
-  seats_available: (seats, seats_taken, registration) => {
-    if (registration) {
-      return `${seats - seats_taken}  seats available`;
+  seats_available: (event) => {
+    if (event.registration) {
+      return `${event.seats - event.seats_taken}  seats available`;
+    } else if (event.title === 'Open Studio & Limited Shop Access') {
+      return 'open availability';
     }
-    return 'open availability';
+    return;
   },
   time: start => new Intl.DateTimeFormat(
     'en-US',

--- a/routes/index.js
+++ b/routes/index.js
@@ -25,7 +25,7 @@ hbs.registerHelper({
     } else if (event.title === 'Open Studio & Limited Shop Access') {
       return 'open availability';
     }
-    return;
+    return 'see event details';
   },
   time: start => new Intl.DateTimeFormat(
     'en-US',

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -10,7 +10,7 @@
   <div class="col s12">
     <div class="card-panel" style="background-color: {{color}}">
       <a href={{url.public}} style="color:black">
-        <span class="calendarText">{{title}}: {{time start}} | {{seats_available seats seats_taken registration}}</span>
+        <span class="calendarText">{{title}}: {{time start}} | {{seats_available this}}</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

Adds minutes to time display for events, and now only open studio has "open availability"
address #15 and #11 

### Screenshots or gifs of the new hotness
Old Sadness:
![](http://g.recordit.co/aH87YU13cC.gif)

New Hotness:
![](http://g.recordit.co/Nq6WKTA2a3.gif)

### How do I verify?

usually the second Shop 61 is at 2:30, and view any closed dates for the lack of "open availability"

### ~Any new dependencies?~

### gif

![](https://media.giphy.com/media/4iqMzLtBO9KSY/giphy.gif)