### PR TITLE
Sticky headers too big mobile

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -4,7 +4,7 @@
     {{dateLong @key}}
   </h3>
   <h4 class="card center-align sticky hide-on-med-and-up">
-    {{dateShort @key}}
+    <span class="card-title">{{dateShort @key}}</span>
   </h4>
   {{#each this}}
   <div class="col s12">


### PR DESCRIPTION
### What does this PR do?

Some headers were still to big on Adam's phone. Addresses #14 

### Screenshots or gifs of the new hotness

Old sadness:
![Screen Shot 2019-11-11 at 3 43 37 PM](https://user-images.githubusercontent.com/6353499/68627073-1448a000-049a-11ea-948c-c7f142fa6b16.png)

New Hotness:
![Screen Shot 2019-11-11 at 3 43 05 PM](https://user-images.githubusercontent.com/6353499/68627085-1b6fae00-049a-11ea-9fc9-fc4219459755.png)


### How do I verify?

Check out on Adam's phone

### ~Any new dependencies?~

### gif

![](https://media.giphy.com/media/xTk9ZMcahswelC60ko/giphy.gif)